### PR TITLE
Glyuan map pin directions link

### DIFF
--- a/app/public/lib/wdmap.js
+++ b/app/public/lib/wdmap.js
@@ -131,6 +131,10 @@ function pins(x) {
 				+ varietals
 				+ "<br><br><b>WineDown Rating: </b><br>"
 				+ rating
+				+ "<br><br><a href='https://www.google.com/maps/dir/?api=1&destination=" 
+				+ escape(data[i].wineryname) + ",+"  
+				+ escape(data[i].address)
+				+ "'target='_blank'>Directions</a>"
 				);
 
 			markers.addLayer(marker);
@@ -171,7 +175,7 @@ function selector() {
 
 //for filtering pins, specifies categories
 function filter() {
-	pins('varietal=' + $('#opts').val() );
+	pins('varietal=' + $('#opts').val());
 }
 function filterWineryName() {
 	pins('wineryname=' + $('#optnames').val());

--- a/dbsetup/db_create.sql
+++ b/dbsetup/db_create.sql
@@ -75,6 +75,7 @@ CREATE VIEW winerypins AS
 	a.lat, 
 	a.lng, 
 	a.hours, 
+	a.address,
 	b.varietal,
 	d.varietals,
 	c.wineryrating


### PR DESCRIPTION
I added a redirect link for directions on each map pin. I had to add 'address' to the 'winerypins' view. 
Use this mysql command to update 'winerypins' without rerunning db_create.sql:

ALTER VIEW winerypins AS
	SELECT a.wineryid, 
	a.wineryname, 
	a.lat, 
	a.lng, 
	a.hours, 
    a.address,
	b.varietal,
	d.varietals,
	c.wineryrating
	FROM winery a 
	LEFT JOIN wine b 
	ON a.wineryid = b.wineryid 
	LEFT JOIN wineryrating c
	ON a.wineryid = c.wineryid
	LEFT JOIN wineryvars d
	ON a.wineryid = d.wineryid;


Each link ends up becoming something like this:

https://www.google.com/maps/dir/?api=1&destination=Terra%20D%27Oro,+20680%20Shenandoah%20School%20Rd%2C%20Plymouth%2C%20CA%2095669%2C%20USA

I've spot checked the wineries with punctuation in their names and it seems to work for our dataset.


Detailed changelog: 

Changes to db_create.sql: 
+added 'address' column to winerypins view

Changes to wdmap.js: 
+Altered pins() function to also link a new tab/window to google maps with directions to winery. 
